### PR TITLE
use recent detailed patches from debian unstable

### DIFF
--- a/drmP.h
+++ b/drmP.h
@@ -65,9 +65,6 @@
 #include <asm/io.h>
 #include <asm/mman.h>
 #include <asm/uaccess.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
-#undef CONFIG_MTRR
-#endif
 #ifdef CONFIG_MTRR
 #include <asm/mtrr.h>
 #endif

--- a/firegl_public.c
+++ b/firegl_public.c
@@ -136,9 +136,6 @@
 #include <asm/processor.h>
 #include <asm/tlbflush.h> // for flush_tlb_page
 #include <asm/cpufeature.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
-#undef CONFIG_MTRR
-#endif
 #ifdef CONFIG_MTRR
 #include <asm/mtrr.h>
 #endif
@@ -634,12 +631,7 @@ static int firegl_major_proc_read(struct seq_file *m, void* data)
 
     len = snprintf(buf, request, "%d\n", major);
 #else
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,3,0)
     len = seq_printf(m, "%d\n", major);
-#else
-    seq_printf(m, "%d\n", major);
-    len = 0;
-#endif
 #endif
 
     KCL_DEBUG1(FN_FIREGL_PROC, "return len=%i\n",len);

--- a/firegl_public.c
+++ b/firegl_public.c
@@ -6463,11 +6463,7 @@ static int KCL_fpu_save_init(struct task_struct *tsk)
       if (!(fpu->state->xsave.xsave_hdr.xstate_bv & XSTATE_FP))
 #else
 	  copy_xregs_to_kernel(&fpu->state.xsave);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
-      if (!(fpu->state.xsave.header.xfeatures & XFEATURE_MASK_FP))
-#else
-      if (!(fpu->state.xsave.header.xfeatures & XSTATE_XP))
-#endif
+      if (!(fpu->state.xsave.header.xfeatures & XSTATE_FP))
 #endif
          return 1;
    } else if (static_cpu_has(X86_FEATURE_FXSR)) {

--- a/firegl_public.c
+++ b/firegl_public.c
@@ -209,6 +209,10 @@
 #include "kcl_io.h"
 #include "kcl_debug.h"
 
+#ifndef XSTATE_FP
+#define XSTATE_FP XFEATURE_MASK_FP
+#endif
+
 // ============================================================
 
 // VM_SHM is deleted in 2.6.18 or higher kernels.
@@ -631,7 +635,11 @@ static int firegl_major_proc_read(struct seq_file *m, void* data)
 
     len = snprintf(buf, request, "%d\n", major);
 #else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
     len = seq_printf(m, "%d\n", major);
+#else
+    seq_printf(m, "%d\n", major);
+#endif
 #endif
 
     KCL_DEBUG1(FN_FIREGL_PROC, "return len=%i\n",len);
@@ -3424,7 +3432,11 @@ int ATI_API_CALL KCL_MEM_MTRR_Support(void)
 int ATI_API_CALL KCL_MEM_MTRR_AddRegionWc(unsigned long base, unsigned long size)
 {
 #ifdef CONFIG_MTRR
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
     return mtrr_add(base, size, MTRR_TYPE_WRCOMB, 1);
+#else
+    return arch_phys_wc_add(base, size);
+#endif
 #else /* !CONFIG_MTRR */
     return -EPERM;
 #endif /* !CONFIG_MTRR */
@@ -3433,7 +3445,12 @@ int ATI_API_CALL KCL_MEM_MTRR_AddRegionWc(unsigned long base, unsigned long size
 int ATI_API_CALL KCL_MEM_MTRR_DeleteRegion(int reg, unsigned long base, unsigned long size)
 {
 #ifdef CONFIG_MTRR
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
     return mtrr_del(reg, base, size);
+#else
+    arch_phys_wc_del(reg);
+    return reg;
+#endif
 #else /* !CONFIG_MTRR */
     return -EPERM;
 #endif /* !CONFIG_MTRR */
@@ -6435,6 +6452,48 @@ int ATI_API_CALL kcl_sscanf(const char * buf, const char * fmt, ...)
     return i;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,2,0)
+/*
+ * Save processor xstate to xsave area.
+ */
+static void _copy_xregs_to_kernel(struct xregs_state *xstate)
+{
+        u64 mask = -1;
+        u32 lmask = mask;
+        u32 hmask = mask >> 32;
+        int err = 0;
+
+        /*WARN_ON(!alternatives_patched);*/
+
+        /*
+         * If xsaves is enabled, xsaves replaces xsaveopt because
+         * it supports compact format and supervisor states in addition to
+         * modified optimization in xsaveopt.
+         *
+         * Otherwise, if xsaveopt is enabled, xsaveopt replaces xsave
+         * because xsaveopt supports modified optimization which is not
+         * supported by xsave.
+         *
+         * If none of xsaves and xsaveopt is enabled, use xsave.
+         */
+        alternative_input_2(
+                "1:"XSAVE,
+                XSAVEOPT,
+                X86_FEATURE_XSAVEOPT,
+                XSAVES,
+                X86_FEATURE_XSAVES,
+                [xstate] "D" (xstate), "a" (lmask), "d" (hmask) :
+                "memory");
+        asm volatile("2:\n\t"
+                     xstate_fault(err)
+                     : "0" (err)
+                     : "memory");
+
+        /* We should never fault when copying to a kernel buffer: */
+        WARN_ON_FPU(err);
+}
+#endif
+
 /** \brief Generate UUID
  *  \param buf pointer to the generated UUID
  *  \return None
@@ -6454,7 +6513,7 @@ static int KCL_fpu_save_init(struct task_struct *tsk)
       fpu_xsave(fpu);
       if (!(fpu->state->xsave.xsave_hdr.xstate_bv & XSTATE_FP))
 #else
-	  copy_xregs_to_kernel(&fpu->state.xsave);
+	  _copy_xregs_to_kernel(&fpu->state.xsave);
       if (!(fpu->state.xsave.header.xfeatures & XSTATE_FP))
 #endif
          return 1;

--- a/firegl_public.c
+++ b/firegl_public.c
@@ -6466,7 +6466,7 @@ static int KCL_fpu_save_init(struct task_struct *tsk)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,4,0)
       if (!(fpu->state.xsave.header.xfeatures & XFEATURE_MASK_FP))
 #else
-      if (!(fpu->state.xsave.header.xfeatures & XSTATE_FP))
+      if (!(fpu->state.xsave.header.xfeatures & XSTATE_XP))
 #endif
 #endif
          return 1;


### PR DESCRIPTION
Hello,

Thanks for your work.  I have been using your patches through many versions of fglrx, you have saved me a ton of time!

[Recently](http://webcache.googleusercontent.com/search?q=cache:n14cpQUmAPoJ:sources.debian.net/patches/patch/fglrx-driver/1:15.9-3~bpo8%252B1/12-4.3.0-build.patch/+&cd=2&hl=en&ct=clnk&gl=us) similar patches [have landed in debian unstable](https://lists.debian.org/debian-backports-changes/2016/01/msg00024.html).  I think these new patches are probably the best to use, since that's what will land in debian & ubuntu, and if there are any bugs in new fglrx, they should be reported against the debian patches.

I have tested this with Ubuntu 15.10, [kernel 4.3.4](http://www.ubuntumaniac.com/2016/01/how-to-upgrade-to-linux-kernel-434.html), Radeon HD 6400M.

The original patches are available [on the debian website](http://http.debian.net/debian/pool/non-free/f/fglrx-driver/fglrx-driver_15.12-2.debian.tar.xz).
